### PR TITLE
fix/side-nav inner-paths

### DIFF
--- a/src/configs/roles.ts
+++ b/src/configs/roles.ts
@@ -32,6 +32,7 @@ const sharedPermissions: Permissions = {
   canViewSettingsContactUs: true,
   canViewSettingsDeactivateAccount: true,
   canViewWallet: true,
+
 };
 
 export const permissionSchema: PermissionsSchema = {
@@ -60,9 +61,9 @@ export const permissionSchema: PermissionsSchema = {
     canViewExpertName: true,
     canViewBidDetails: true,
     notAbleToViewComponents: [
-      "sidenav-educational-info",
-      "sidenav-experience",
-      "sidenav-certificate",
+      // "sidenav-educational-info",
+      // "sidenav-experience",
+      // "sidenav-certificate",
       "button-request-a-project",
       "table-client-projects",
       "headertabs-client-projects",

--- a/src/hooks/usePreviousPath.tsx
+++ b/src/hooks/usePreviousPath.tsx
@@ -7,13 +7,23 @@ export default function usePreviousPath() {
   const router = useRouter();
   const [previousPath, setPreviousPath] = useState<string | null>(null);
   const [isinnerPath,setIsinnerPath] = useState(false);
-  const innerPathsList = ["/bid/rfp-name","/profile"]
+  const [isProfilePath,setIsProfilePath] = useState(false);
+  const innerPathsList = ["/bid/rfp-name","/profile","/certificate","/experience","/educational-info"]
+  const innerProfilePathsList = ["/profile","/certificate","/experience","/educational-info"]
   const checkIfInnerPath = ()=>{
     if(innerPathsList?.includes(router.pathname)){
       setIsinnerPath(true);
+
+      if(innerProfilePathsList.includes(router.pathname)){
+        setIsProfilePath(true);
+      }
+      else{
+        setIsProfilePath(false);
+      }
     }
     else {
       setIsinnerPath(false);
+      setIsProfilePath(false);
     }
   }
   useEffect(() => {
@@ -32,5 +42,5 @@ export default function usePreviousPath() {
     };
   }, [router.events, router.pathname]);
 
-  return {previousPath,isinnerPath};
+  return {previousPath,isinnerPath,isProfilePath};
 }

--- a/src/layouts/dashboard/Inner-path-item.tsx
+++ b/src/layouts/dashboard/Inner-path-item.tsx
@@ -33,7 +33,7 @@ export const SideNavInnerItem = (props: { previousPath: any }) => {
           gap: "15px",
         }}
         onClick={() => {
-          router.back();
+          router.push(previousPath);
         }}
       >
         <Box>

--- a/src/layouts/dashboard/config.tsx
+++ b/src/layouts/dashboard/config.tsx
@@ -52,48 +52,7 @@ export const items = [
       </SvgIcon>
     ),
   },
-  {
-    // used in symline
-    external: false,
-    disabled: false,
-    menu: false,
-    id: "sidenav-educational-info",
-    title: "Educational info",
-    path: "/educational-info",
-    icon: (
-      <SvgIcon fontSize="small">
-        <FindInPageIcon />
-      </SvgIcon>
-    ),
-  },
-  {
-    // used in symline
-    external: false,
-    disabled: false,
-    menu: false,
-    id: "sidenav-experience",
-    title: "Experience",
-    path: "/experience",
-    icon: (
-      <SvgIcon fontSize="small">
-        <SchoolIcon />
-      </SvgIcon>
-    ),
-  },
-  {
-    // used in symline
-    external: false,
-    disabled: false,
-    menu: false,
-    id: "sidenav-certificate",
-    title: "Certificate",
-    path: "/certificate",
-    icon: (
-      <SvgIcon fontSize="small">
-        <WorkspacePremiumIcon />
-      </SvgIcon>
-    ),
-  },
+  
   {
     // used in symline
     external: false,
@@ -104,6 +63,20 @@ export const items = [
     icon: (
       <SvgIcon fontSize="small">
         <VideocamIcon />
+      </SvgIcon>
+    ),
+  },
+  {
+    // used in symline
+    external: false,
+    disabled: false,
+    menu: false,
+    id: "sidenav-profile",
+    title: "Profile",
+    path: "/profile",
+    icon: (
+      <SvgIcon fontSize="small">
+        <AccountCircleIcon />
       </SvgIcon>
     ),
   },
@@ -119,20 +92,7 @@ export const items = [
       </SvgIcon>
     ),
     children: [
-      {
-        // used in symline
-        external: false,
-        disabled: false,
-        menu: false,
-        id: "sidenav-profile",
-        title: "Profile",
-        path: "/profile",
-        icon: (
-          <SvgIcon fontSize="small">
-            <AccountCircleIcon />
-          </SvgIcon>
-        ),
-      },
+
       {
         external: false,
         disabled: false,
@@ -201,3 +161,62 @@ export const items = [
     ],
   },
 ];
+
+export const profileItems = [
+  {
+    // used in symline
+    external: false,
+    disabled: false,
+    menu: false,
+    id: "sidenav-profile",
+    title: "Profile",
+    path: "/profile",
+    icon: (
+      <SvgIcon fontSize="small">
+        <AccountCircleIcon />
+      </SvgIcon>
+    ),
+  },
+  {
+    // used in symline
+    external: false,
+    disabled: false,
+    menu: false,
+    id: "sidenav-educational-info",
+    title: "Educational info",
+    path: "/educational-info",
+    icon: (
+      <SvgIcon fontSize="small">
+        <FindInPageIcon />
+      </SvgIcon>
+    ),
+  },
+  {
+    // used in symline
+    external: false,
+    disabled: false,
+    menu: false,
+    id: "sidenav-experience",
+    title: "Experience",
+    path: "/experience",
+    icon: (
+      <SvgIcon fontSize="small">
+        <SchoolIcon />
+      </SvgIcon>
+    ),
+  },
+  {
+    // used in symline
+    external: false,
+    disabled: false,
+    menu: false,
+    id: "sidenav-certificate",
+    title: "Certificate",
+    path: "/certificate",
+    icon: (
+      <SvgIcon fontSize="small">
+        <WorkspacePremiumIcon />
+      </SvgIcon>
+    ),
+  },
+]

--- a/src/layouts/dashboard/side-nav.tsx
+++ b/src/layouts/dashboard/side-nav.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mui/material';
 import React ,{useEffect, useState} from 'react';
 import { Scrollbar } from '../../components/scrollbar';
-import { items } from './config';
+import { items,profileItems } from './config';
 import { SideNavItem } from './side-nav-item';
 import { Theme } from '@mui/material';
 import RoleBasedRender from '@/hocs/RoleBasedRender';
@@ -27,7 +27,7 @@ export const SideNav = (props: { open: any; onClose: any; }) => {
   const { open, onClose } = props;
   const pathname = usePathname();
   const lgUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('lg'));
-  const {previousPath,isinnerPath} = usePreviousPath();
+  const {previousPath,isinnerPath,isProfilePath} = usePreviousPath();
   const {t} = useTranslation();
   const content = (
     <Scrollbar
@@ -99,6 +99,39 @@ export const SideNav = (props: { open: any; onClose: any; }) => {
             }}
           >
             {items.map((item: any, key) => {
+              const active = item.path ? (pathname === item.path) : false;
+
+              return (
+                <RoleBasedRender key={key} componentId={item?.id ?? ``}>
+                  <SideNavItem
+                    active={active}
+                    disabled={item.disabled}
+                    external={item.external}
+                    icon={item.icon}
+                    key={item.title}
+                    path={item.path}
+                    title={item.title}
+                    items={item.children}
+                    amount={item.amount}
+                  />
+                </RoleBasedRender>
+              );
+            })}
+          </Stack>
+          <Stack
+            component="ul"
+            spacing={0.5}
+            sx={{
+              listStyle: 'none',
+              p: 0,
+              m: 0,
+              // display: isinnerPath ? "none":'flex',
+              height: isProfilePath ? "auto":'0',
+              transition: 'height 0.3s ease',
+              overflow: 'hidden'
+            }}
+          >
+            {profileItems.map((item: any, key) => {
               const active = item.path ? (pathname === item.path) : false;
 
               return (


### PR DESCRIPTION
give service provider permission to see:
- "sidenav-educational-info"
- "sidenav-experience"
-"sidenav-certificate"

edit side nav to sketch view (adding another array in config.tsx file for show profile items)

